### PR TITLE
Fix/broken links

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -54509,8 +54509,7 @@ video {
   align-items: center;
 }
 .navbar-logo span::before{
-  content: url('./../img/logo_genue.png');  
-  border-radius: 50%; 
+  border-radius: 50%;
   margin-right: 15px;
   height: 40px;
 }

--- a/content/1.guides/6.no-code-UI-editor/0.index.md
+++ b/content/1.guides/6.no-code-UI-editor/0.index.md
@@ -1,5 +1,5 @@
 ---
 title: " "
-redirect: /guides/quickstart
+redirect: /guides/no-code-ui-editor/quickstart
 navigation: false
 ---

--- a/content/1.guides/6.no-code-UI-editor/4.designing-the-UI-lowcode.md
+++ b/content/1.guides/6.no-code-UI-editor/4.designing-the-UI-lowcode.md
@@ -1,6 +1,6 @@
 # Designing the UI with the low-code API
 
-If you'd prefer to implement the UI in pure Julia, Genie Framework provides a [low-code API](/docs/ui) with which you can declare the UI components in the Julia code. These API calls generate the HTML code for many standard HTML elements and Vue.js components from the [Quasar](https://quasar.dev/vue-components/) framework.
+If you'd prefer to implement the UI in pure Julia, Genie Framework provides a [low-code API](/reference/reactive-ui) with which you can declare the UI components in the Julia code. These API calls generate the HTML code for many standard HTML elements and Vue.js components from the [Quasar](https://quasar.dev/vue-components/) framework.
 
 | GF API  function | Generated component  | Example usage
 |------------------|----------------------|----------

--- a/content/2.reference/3.reactive-UI/0.introduction.md
+++ b/content/2.reference/3.reactive-UI/0.introduction.md
@@ -51,7 +51,7 @@ end
 
 
 ::code-block{label="UI preview" preview}
-<img style="display:block;width:35%;max-width:100%;margin-left:auto;margin-right:auto" src="/docs/ui/enternumber.png">
+<img style="display:block;width:35%;max-width:100%;margin-left:auto;margin-right:auto" src="/assets/docs/ui/enternumber.png">
 ::
 
 ::

--- a/content/2.reference/3.reactive-UI/3.styling.md
+++ b/content/2.reference/3.reactive-UI/3.styling.md
@@ -44,5 +44,5 @@ Moreover, the Quasar components come with their own pre-defined CSS classes. The
 </div>
 ```
 
-Check the official Quasar documentation for a comprehensive list of available classes: [Quasar CSS Helpers](https://quasar.dev/style/css-helpers).
+Check the official Quasar documentation for a comprehensive list of available classes: [Quasar CSS Helpers](https://quasar.dev/style/typography).
 

--- a/content/2.reference/3.reactive-UI/99.API/Components/icons.md
+++ b/content/2.reference/3.reactive-UI/99.API/Components/icons.md
@@ -8,7 +8,7 @@
 icon(name::Union{String,Symbol}, args...; content::Union{String,Vector,Function} = "", kwargs...)
 ```
 
-Stipple supports out of the box: [Material Icons](https://fonts.google.com/icons?selected=Material+Icons) , [Font Awesome](https://fontawesome.com/icons), [Ionicons](https://ionic.io/ionicons), [MDI](https://materialdesignicons.com/), [Eva Icons](https://akveo.github.io/eva-icons/#/), [Themify Icons](https://themify.me/themify-icons), [Line Awesome](https://icons8.com/line-awesome) and [Bootstrap Icons](https://icons.getbootstrap.com/).
+Stipple supports out of the box: [Material Icons](https://fonts.google.com/icons) , [Font Awesome](https://fontawesome.com/icons), [Ionicons](https://ionic.io/ionicons), [MDI](https://materialdesignicons.com/), [Eva Icons](https://akveo.github.io/eva-icons/#/), [Themify Icons](https://themify.me/themify-icons), [Line Awesome](https://icons8.com/line-awesome) and [Bootstrap Icons](https://icons.getbootstrap.com/).
 
 Furthermore you can [add support by yourself](https://v1.quasar.dev/vue-components/icon#custom-mapping) for any icon lib.
 

--- a/content/3.tutorials/1.written/1.reactive-UI-basics.md
+++ b/content/3.tutorials/1.written/1.reactive-UI-basics.md
@@ -102,7 +102,7 @@ end
 
 Next, we've defined the `count_vowels` function right in `app.jl` between the imports and the reactive code block.
 
-You'll usually want to add some code to perform data analysis tasks. While for simple apps it is sufficient to have all Julia code in `app.jl`, it is also possible to import code from other files as shown in [this guide](/guides/adding-your-julia-code#writing-julia-code-in-separate-files).
+You'll usually want to add some code to perform data analysis tasks. While for simple apps it is sufficient to have all Julia code in `app.jl`, it is also possible to import code from other files as shown in [this guide](/guides/no-code-ui-editor/adding-your-julia-code#writing-julia-code-in-separate-files).
 
 #### 3. Reactive code
 

--- a/content/3.tutorials/1.written/1.reactive-UI-basics.md
+++ b/content/3.tutorials/1.written/1.reactive-UI-basics.md
@@ -161,13 +161,13 @@ Another directive is `v-on:click`, which executes some code when the user clicks
 <q-btn label="Reset!" v-on:click="reset = !reset"></q-btn>
 ```
 
-To learn more about the available components and their usage, check out the [Documentation](/docs/reactive-ui) and the [app gallery](/app-gallery).
+To learn more about the available components and their usage, check out the [Documentation](/reference/reactive-ui) and the [app gallery](/app-gallery).
 
 Besides the UI components, it is possible to display a variable's value with the double mustache syntax `{{}}`. Furthermore, this syntax accepts arbitrary JavaScript expressions that will be evaluated when the page loads.
 
 ## Building the UI with the no-code editor
 
-Given the long list of UI components and their parameters, it can be difficult to get started building UIs for your Genie apps. For this reason, we have created a no-code editor with which you can implement the UI with simple drag and drop of components. This editor is available on [Genie Cloud](geniecloud.io) and in the [Genie Builder](https://marketplace.visualstudio.com/items?itemName=GenieBuilder.geniebuilder) plugin for VSCode. See the [usage guide](/guides/designing-the-ui) for more details.
+Given the long list of UI components and their parameters, it can be difficult to get started building UIs for your Genie apps. For this reason, we have created a no-code editor with which you can implement the UI with simple drag and drop of components. This editor is available on [Genie Cloud](geniecloud.io) and in the [Genie Builder](https://marketplace.visualstudio.com/items?itemName=GenieBuilder.geniebuilder) plugin for VSCode. See the [usage guide](/guides/no-code-ui-editor/designing-the-ui) for more details.
 
 <img style="display:block;width:600px;max-width:100%;margin-left:auto;margin-right:auto" src="/assets/guides/app-development/vscode2.png">
 

--- a/content/3.tutorials/1.written/2.map-charts.md
+++ b/content/3.tutorials/1.written/2.map-charts.md
@@ -52,7 +52,7 @@ Plot(trace, layout)
 
 #### PlotlyJS with Genie 
 
-[Plotting in Genie](/docs/reactive-ui/plotting) with PlotlyJS is straightforward: just define the trace and layout variables and expose them to the UI with `@out`. For example, the previous scatter plot example would become:
+[Plotting in Genie](/reference/reactive-ui/plotting) with PlotlyJS is straightforward: just define the trace and layout variables and expose them to the UI with `@out`. For example, the previous scatter plot example would become:
 
 ```julia
 @app begin

--- a/content/3.tutorials/1.written/4.CSV-uploader.md
+++ b/content/3.tutorials/1.written/4.CSV-uploader.md
@@ -21,7 +21,7 @@ The full code and some sample CSV files can be downloaded from this
 ## Setup and app structure
 
 We'll use `GenieFramework.jl`, `DataFrames.jl` and `CSV.jl` to build the
-app. To install them, use the builtin [package manager](/guides/quickstart#add-your-julia-code), or launch a REPL and enter Pkg mode with `]` and type in the following
+app. To install them, use the builtin [package manager](/guides/no-code-ui-editor/quickstart#add-your-julia-code), or launch a REPL and enter Pkg mode with `]` and type in the following
 command:
 
 ``` julia
@@ -145,7 +145,7 @@ function that stores the file in the request header, we've used Julia's
 `do end` syntax which builds an anonymous function with the code in the
 block and passes it to `route`.
 
-The upload box is now finished and working. Give it a try by [launching a preview](/guides/quickstart#launch-the-workspace) in a new browser tab.
+The upload box is now finished and working. Give it a try by [launching a preview](/guides/no-code-ui-editor/quickstart#launch-the-workspace) in a new browser tab.
 
 ### File and column selectors
 

--- a/content/3.tutorials/1.written/6.iris-clustering-dashboard.md
+++ b/content/3.tutorials/1.written/6.iris-clustering-dashboard.md
@@ -9,7 +9,7 @@ toc: true
 
 # Dashboard for Iris dataset clustering
 
-This tutorial will guide you through using the [low-code API](/guides/designing-the-ui-lowcode) to develop a web app for
+This tutorial will guide you through using the [low-code API](/guides/no-code-ui-editor/designing-the-ui-lowcode) to develop a web app for
 the classification of flower samples belonging to several species. We’ll
 be using the Iris Dataset, which is commonly used to showcase machine
 learning applications. In this dataset, we have tabular data describing
@@ -35,7 +35,7 @@ A Genie app is typically developed in three parts:
 
 The tutorial will go into each of these steps and, by the end, we’ll
 have a beautiful dashboard like the one in the figure below. The full
-code can be found [here](https://github.com/GenieFramework/GenieBuilderDemos/tree/main/iristutorial).
+code can be found [here](https://github.com/GenieFramework/GenieBuilderDemos/tree/main/iris).
 
 
 <img style="display:block;width:60%;margin-left:auto;margin-right:auto" src="/assets/tutorials/iris-clustering-dashboard/irisview.png" />

--- a/content/4.examples/0.index.md
+++ b/content/4.examples/0.index.md
@@ -4,6 +4,6 @@ title: Instructions
 
 ## Code examples
 
-This section contains short code examples showcasing the features of [Genie Framework](/docs/overview). To use them, simply copy and paste them into a Julia `app.jl` file and run it with `include("app.jl")`.
+This section contains short code examples showcasing the features of [Genie Framework](/). To use them, simply copy and paste them into a Julia `app.jl` file and run it with `include("app.jl")`.
 
 If you'd like to contribute with an example, open a pull request on the [CodeExamples](https://github.com/GenieFramework/CodeExamples) repository.


### PR DESCRIPTION
Just missed some links to fix. The current situation related to broken links is as follows:
1. False broken links that we should not worry about:
* http://localhost:8000/
2. Demos that are not working:
* https://histogram-pereg.dev.geniecloud.app/
* https://nntrain-pere.geniecloud.app/
3. @ref links (a little bit annoying):
* https://learn.genieframework.com/reference/server/api/@ref
* https://learn.genieframework.com/reference/database/api/@ref
5. Guides that have not been written yet:
* https://learn.genieframework.com/guides/deploying-the-app
* https://learn.genieframework.com/guides/guides/app-templates/MVC-web-apps



