### PR TITLE
Naming inconsistency

### DIFF
--- a/content/1.guides/2.first-dashboard.md
+++ b/content/1.guides/2.first-dashboard.md
@@ -14,10 +14,10 @@ This guide will show you how to create a dashboard which displays statistics abo
 
 ### Project structure
 
-When building a Genie app, the usual assumption is that you already have some code performing some data analysis that you want to turn into a web app. For this demo, we'll start with a `StatisticalAnalysis` module  with the following content:
+When building a Genie app, the usual assumption is that you already have some code performing some data analysis that you want to turn into a web app. For this demo, we'll start with a `StatisticAnalysis` module  with the following content:
 
 
-```julia [StatisticalAnalysis.jl]
+```julia [StatisticAnalysis.jl]
 module StatisticAnalysis
 
 export gen_numbers, calc_mean


### PR DESCRIPTION
Module and File name have been called StatisticAnalysis and StatisticalAnalysis on the same page. That was irritating. I change StatisticalAnalysis to StatisticAnalysis as StatisticAnalysis is the name used further down the text