### PR TITLE
Ensure loading of plotly_traces

### DIFF
--- a/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
+++ b/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
@@ -87,12 +87,9 @@ end
 end
 ```
 
-!!! note
-    The `plotly_traces` function is loaded by `Plots.plotly()` in the integration
-    with `PlotlyBase` and `PlotlyKaleido`. Therefore, `PlotlyBase` and `PlotlyKaleido`
-    should be available installed and in the environment when `Plots.plotly()` is called
-    for `plotly_traces` to be defined.
-
+::alert{type="info"}
+The `plotly_traces` function is loaded by `Plots.plotly()` in the integration with `PlotlyBase` and `PlotlyKaleido`. Therefore, `PlotlyBase` and `PlotlyKaleido` should be available installed and in the environment when `Plots.plotly()` is called for `plotly_traces` to be defined.
+::
 ### Defining plots in HTML
 
 You can also define the plot entirely in the HTML code and just bind the data to Julia variables,

--- a/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
+++ b/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
@@ -66,7 +66,7 @@ or with the `plotly` tag in the HTML code
 ### Defining plots from Plots.jl
 
 It is also possible to obtain the `plotdata` from a plot defined with
-[Plots.jl](https://docs.juliaplots.org/stable/) using the PlotlyJS backend and the `Plots.plotly_traces` function as follows:
+[Plots.jl](https://docs.juliaplots.org/stable/) using the Plotly backend and the `Plots.plotly_traces` function as follows:
 
 ```julia
 module App
@@ -86,6 +86,12 @@ end
 @page("/", ui)
 end
 ```
+
+!!! note
+    The `plotly_traces` function is loaded by `Plots.plotly()` in the integration
+    with `PlotlyBase` and `PlotlyKaleido`. Therefore, `PlotlyBase` and `PlotlyKaleido`
+    should be available installed and in the environment when `Plots.plotly()` is called
+    for `plotly_traces` to be defined.
 
 ### Defining plots in HTML
 

--- a/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
+++ b/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
@@ -71,8 +71,8 @@ It is also possible to obtain the `plotdata` from a plot defined with
 ```julia
 module App
 using GenieFramework
-import PlotlyBase,PlotlyJS, Plots
-Plots.plotlyjs()
+import PlotlyBase, PlotlyKaleido, Plots
+Plots.plotly()
 
 p = Plots.plot([1, 2, 3], show=false)
 @app begin


### PR DESCRIPTION
As you can see in https://github.com/JuliaPlots/Plots.jl/pull/4849, the `plotlybase.jl` file in which the `plotly_traces` function is is only loaded if `PlotlyBase` and `PlotlyKaleido` are available and `plotly()` is called.