### PR TITLE
Add plotly_layout to Plots integration

### DIFF
--- a/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
+++ b/content/1.docs/2.reference/3.reactive-UI/5.plotting.md
@@ -66,7 +66,8 @@ or with the `plotly` tag in the HTML code
 ### Defining plots from Plots.jl
 
 It is also possible to obtain the `plotdata` from a plot defined with
-[Plots.jl](https://docs.juliaplots.org/stable/) using the Plotly backend and the `Plots.plotly_traces` function as follows:
+[Plots.jl](https://docs.juliaplots.org/stable/) using the Plotly backend and the
+`Plots.plotly_traces`/`Plots.plotly_layout` functions as follows:
 
 ```julia
 module App
@@ -77,10 +78,11 @@ Plots.plotly()
 p = Plots.plot([1, 2, 3], show=false)
 @app begin
     @out traces = Plots.plotly_traces(p)
+    @out layout = Plots.plotly_layout(p)
 end
 
 function ui()
-    plot(:traces)
+    plot(:traces, layout=:layout)
 end
 
 @page("/", ui)


### PR DESCRIPTION
This is defined here:
https://github.com/JuliaPlots/Plots.jl/blob/8ac431115ce3c1cbbff0eb70f6bc2265e492b33b/src/backends/plotly.jl#L194
and used both by `PlotlyBase` in
https://github.com/JuliaPlots/Plots.jl/blob/8ac431115ce3c1cbbff0eb70f6bc2265e492b33b/src/backends/plotlybase.jl#L13
and PlotlyJS in
https://github.com/JuliaPlots/Plots.jl/blob/8ac431115ce3c1cbbff0eb70f6bc2265e492b33b/src/backends/plotlyjs.jl#L16