### PR TITLE
Update 3.migrations.md

### DIFF
--- a/content/1.docs/2.reference/4.Database/3.migrations.md
+++ b/content/1.docs/2.reference/4.Database/3.migrations.md
@@ -38,6 +38,41 @@ julia> SearchLight.query("SELECT name FROM sqlite_master WHERE type ='table' AND
 
 The result is a `DataFrame` object.
 
+---
+
+#### Creating our Book model
+
+SearchLight, just like Genie, uses the convention-over-configuration design pattern. It prefers for things to be setup
+in a certain way and provides sensible defaults, versus having to define everything in extensive configuration files.
+And fortunately, we don't even have to remember what these conventions are, as SearchLight also comes with an extensive
+set of generators.
+
+Lets ask SearchLight to create a new model:
+
+```julia
+julia> SearchLight.Generator.newresource("Book")
+
+[ Info: New model created at /Users/adrian/Dropbox/Projects/MyGenieApp/app/resources/books/Books.jl
+[ Info: New table migration created at /Users/adrian/Dropbox/Projects/MyGenieApp/db/migrations/2020020909574048_create_table_books.jl
+[ Info: New validator created at /Users/adrian/Dropbox/Projects/MyGenieApp/app/resources/books/BooksValidator.jl
+[ Info: New unit test created at /Users/adrian/Dropbox/Projects/MyGenieApp/test/books_test.jl
+```
+
+SearchLight has created the `Books.jl` model, the `*_create_table_books.jl` migration file, the `BooksValidator.jl` model
+validator and the `books_test.jl` test file.
+
+---
+**HEADS UP**
+
+The first part of the migration file will be different for you!
+
+The `*_create_table_books.jl` file will be named differently as the first part of the name is the file creation timestamp.
+This timestamp part guarantees that names are unique and file name clashes are avoided (for example when working as a
+team a creating similar migration files).
+
+---
+
+
 #### Writing the table migration
 
 Lets begin by writing the migration to create our books table. SearchLight provides a powerful DSL for writing migrations.


### PR DESCRIPTION
added missing section with command `SearchLight.Generator.newresource("Book")` which is what creates the `*_create_table_books.jl` migration file

This is just a copy pasta of https://learn.genieframework.com/tutorials/mvc-books-app#creating-our-book-model