### PR TITLE
Update 1.reactive-UI-basics.md to include 'y' in the vowel list

### DIFF
--- a/content/3.tutorials/1.reactive-UI-basics.md
+++ b/content/3.tutorials/1.reactive-UI-basics.md
@@ -51,7 +51,7 @@ using GenieFramework
 @genietools
 
 function count_vowels(message)
-    sum([c ∈ ['a', 'e', 'i', 'o', 'u'] for c in lowercase(message)])
+    sum([c ∈ ['a', 'e', 'i', 'o', 'u', 'y'] for c in lowercase(message)])
 end
 
 @app begin


### PR DESCRIPTION
I believe 'y' is a vowel in English, as in French. 

As an example, a word like 'city' has 2 vowels.
It's minor and doesn't invalidate the example...

Best