### PR TITLE
Document where to find said panel and the Pro License is not required

### DIFF
--- a/content/1.geniebuilder/docs/0.index.md
+++ b/content/1.geniebuilder/docs/0.index.md
@@ -24,7 +24,7 @@ Once the extension is installed, you'll see a new button in the bottom bar of th
 
 <img class="border-gray-300" style="display:block;width:55%;max-width:100%;margin-left:auto;margin-right:auto" src="/assets/docs/gb/gbrunning.png">
 
-After a moment, the button will change to "GB running", and you'll see the new GENIE tab in the left sidebar.
+After a moment, the button will change to "GB running", and you'll see the new GENIE tab in the left sidebar in the Explorer tab. The Genie Builder tab is for [Code Assistant](/geniebuilder/docs/ai-assistant) which is a Pro feature. You can continue this tutorial without a Pro license.
 
 <img class="border-gray-300" style="display:block;width:25%;max-width:100%;margin-left:auto;margin-right:auto" src="/assets/docs/gb/newappmenu.png">
 


### PR DESCRIPTION
I initially thought that a Pro license would be required to access that panel. It isn't. The panel just isn't under the Genie Builder Tab currently.

This doc change makes it easier for user to follow and not be misslead by the Genii builder side bar tab.